### PR TITLE
Fix last endianess test problem

### DIFF
--- a/astroscrappy/tests/test_utils.py
+++ b/astroscrappy/tests/test_utils.py
@@ -189,7 +189,7 @@ def test_subsample():
 
 def test_rebin():
     a = np.ascontiguousarray(np.random.random((2002, 2002)), dtype=np.float32)
-    a = a.astype('<f4')
+    a = a.astype('f4')
     nprebin = np.zeros((1001, 1001), dtype=np.float32).astype('f4')
     for i in range(1001):
         for j in range(1001):


### PR DESCRIPTION
Hi, I just found your endianess fix at 5b5ce99 for issue #7. This one works [almost](https://buildd.debian.org/status/fetch.php?pkg=astroscrappy&arch=powerpc&ver=1.0.3-4&stamp=1450097271), however one `astype()` is still wrong. This is [fixed](https://buildd.debian.org/status/fetch.php?pkg=astroscrappy&arch=powerpc&ver=1.0.3-5&stamp=1450099984) with this pull request.