### PR TITLE
Update tests to include python 3.5 and  numpy 1.10 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ python:
     - 2.7
     - 3.3
     - 3.4
+    - 3.5
     # This is just for "egg_info".  All other builds are explicitly given in the matrix
 env:
     global:
@@ -57,6 +58,8 @@ matrix:
           env: SETUP_CMD='test'
         - python: 3.4
           env: SETUP_CMD='test'
+        - python: 3.5
+          env: SETUP_CMD='test'
 
         # Try older numpy versions
         - python: 2.7
@@ -65,6 +68,8 @@ matrix:
           env: NUMPY_VERSION=1.7 SETUP_CMD='test'
         - python: 2.7
           env: NUMPY_VERSION=1.6 SETUP_CMD='test'
+        - python: 2.7
+          env: NUMPY_VERSION=1.10 SETUP_CMD='test'
 
 before_install:
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,12 +45,10 @@ matrix:
         # Try Astropy development version
         - python: 2.7
           env: ASTROPY_VERSION=development SETUP_CMD='test'
-        - python: 3.3
+        - python: 3.5
           env: ASTROPY_VERSION=development SETUP_CMD='test'
 
         # Try all python versions with the latest numpy
-        - python: 2.6
-          env: SETUP_CMD='test'
         - python: 2.7
           env: SETUP_CMD='test'
         - python: 3.4

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,6 @@ addons:
 python:
     - 2.6
     - 2.7
-    - 3.3
     - 3.4
     - 3.5
     # This is just for "egg_info".  All other builds are explicitly given in the matrix
@@ -24,7 +23,7 @@ env:
         # The following versions are the 'default' for tests, unless
         # overidden underneath. They are defined here in order to save having
         # to repeat them for all configurations.
-        - NUMPY_VERSION=1.9
+        - NUMPY_VERSION=1.10
         - ASTROPY_VERSION=stable
         - CONDA_INSTALL='conda install -c astropy-ci-extras --yes'
         - PIP_INSTALL='pip install'
@@ -54,8 +53,6 @@ matrix:
           env: SETUP_CMD='test'
         - python: 2.7
           env: SETUP_CMD='test'
-        - python: 3.3
-          env: SETUP_CMD='test'
         - python: 3.4
           env: SETUP_CMD='test'
         - python: 3.5
@@ -63,13 +60,11 @@ matrix:
 
         # Try older numpy versions
         - python: 2.7
+          env: NUMPY_VERSION=1.9 SETUP_CMD='test'
+        - python: 2.7
           env: NUMPY_VERSION=1.8 SETUP_CMD='test'
         - python: 2.7
           env: NUMPY_VERSION=1.7 SETUP_CMD='test'
-        - python: 2.7
-          env: NUMPY_VERSION=1.6 SETUP_CMD='test'
-        - python: 2.7
-          env: NUMPY_VERSION=1.10 SETUP_CMD='test'
 
 before_install:
 

--- a/astroscrappy/tests/test_astroscrappy.py
+++ b/astroscrappy/tests/test_astroscrappy.py
@@ -36,7 +36,7 @@ for i in range(100):
     imdata += gaussian(imdata.shape, x, y, brightness, 3.5)
 
 # Add the poisson noise
-imdata = np.random.poisson(imdata)
+imdata = np.float32(np.random.poisson(imdata))
 
 # Add readnoise
 imdata += np.random.normal(0.0, 10.0, size=(1001, 1001))


### PR DESCRIPTION
This PR updates the test matrix to include the latest python/numpy versions. The initial commit will fail (to demonstrate that there is a problem on numpy 1.10), then a fix and broader update of the test matrix is on its way.