### PR TITLE
Changes to support building on Windows 

### DIFF
--- a/astroscrappy/utils/imutils.h
+++ b/astroscrappy/utils/imutils.h
@@ -10,6 +10,11 @@
 #ifndef IMUTILS_H_
 #define IMUTILS_H_
 
+/* Including definitions of the standard int types is necesssary for Windows,
+ * and does no harm on other platforms. 
+ */
+#include <stdint.h> 
+
 /* Define a bool type because there isn't one built in ANSI C */
 typedef uint8_t bool;
 #define true 1

--- a/astroscrappy/utils/medutils.h
+++ b/astroscrappy/utils/medutils.h
@@ -10,6 +10,11 @@
 #ifndef MEDUTILS_H_
 #define MEDUTILS_H_
 
+/* Including definitions of the standard int types is necesssary for Windows,
+ * and does no harm on other platforms. 
+ */
+#include <stdint.h> 
+
 /* Define a bool type because there isn't one built in ANSI C */
 typedef uint8_t bool;
 #define true 1


### PR DESCRIPTION
This fixes (almost) all of the compilation issues. The only one that still comes up is that `stdint.h` isn't included with the free version of the MS compiler used to build python 2.7. One more reason to switch to python 3.5!