### PR TITLE
respect user compiling flags

### DIFF
--- a/astroscrappy/utils/setup_package.py
+++ b/astroscrappy/utils/setup_package.py
@@ -73,16 +73,12 @@ def get_extensions():
                     sources=med_sources,
                     include_dirs=include_dirs,
                     libraries=libraries,
-                    language="c",
-                    extra_compile_args=['-g', '-O3', '-funroll-loops',
-                                        '-ffast-math'])
+                    language="c")
     ext_im = Extension(name=str("astroscrappy.utils.image_utils"),
                     sources=im_sources,
                     include_dirs=include_dirs,
                     libraries=libraries,
-                    language="c",
-                    extra_compile_args=['-g', '-O3', '-funroll-loops',
-                                        '-ffast-math'])
+                    language="c")
 
     has_openmp, outputs = check_openmp()
     if has_openmp:


### PR DESCRIPTION
Depending on compilers, -O3, -funroll-loops and -ffast-math are not the fastest, and the user can not remove them.
This small patch lets the the user CFLAGS standard variable being respected instead.
