### PR TITLE
correct spelling mistakes

### DIFF
--- a/astroscrappy/astroscrappy.pyx
+++ b/astroscrappy/astroscrappy.pyx
@@ -644,7 +644,7 @@ def gausskernel(float psffwhm, int kernsize):
 
 def gaussxkernel(float psffwhm, int kernsize):
     """gaussxkernel(psffwhm, kernsize)\n
-    Calculate a Guassian kernel in the x-direction.
+    Calculate a Gaussian kernel in the x-direction.
 
     This can be used for spectroscopic data.
 
@@ -675,7 +675,7 @@ def gaussxkernel(float psffwhm, int kernsize):
 
 def gaussykernel(float psffwhm, int kernsize):
     """gaussykernel(psffwhm, kernsize)\n
-    Calculate a Guassian kernel in the y-direction.
+    Calculate a Gaussian kernel in the y-direction.
 
     This can be used for spectroscopic data.
 

--- a/astroscrappy/utils/median_utils.pyx
+++ b/astroscrappy/utils/median_utils.pyx
@@ -317,7 +317,7 @@ def sepmedfilt3(np.ndarray[np.float32_t, ndim=2, mode='c', cast=True] dsep3):
     -----
     The separable median medians the rows followed by the columns instead of
     using a square window. Therefore it is not identical to the full median
-    filter but it is approximatly the same, but it is signifcantly faster.
+    filter but it is approximately the same, but it is significantly faster.
     The median filter is not calculated for a 1 pixel border around the image.
     These pixel values are copied from the input data. The array needs to be
     C-contiguous order. Wrapper for PySepMedFilt3 in medutils.
@@ -354,7 +354,7 @@ def sepmedfilt5(np.ndarray[np.float32_t, ndim=2, mode='c', cast=True] dsep5):
     -----
     The separable median medians the rows followed by the columns instead of
     using a square window. Therefore it is not identical to the full median
-    filter but it is approximatly the same, but it is signifcantly faster.
+    filter but it is approximately the same, but it is significantly faster.
     The median filter is not calculated for a 2 pixel border around the image.
     These pixel values are copied from the input data. The array needs to be
     C-contiguous order. Wrapper for PySepMedFilt5 in medutils.
@@ -392,7 +392,7 @@ def sepmedfilt7(np.ndarray[np.float32_t, ndim=2, mode='c', cast=True] dsep7):
     -----
     The separable median medians the rows followed by the columns instead of
     using a square window. Therefore it is not identical to the full median
-    filter but it is approximatly the same, but it is signifcantly faster.
+    filter but it is approximately the same, but it is significantly faster.
     The median filter is not calculated for a 3 pixel border around the image.
     These pixel values are copied from the input data. The array needs to be
     C-contiguous order. Wrapper for PySepMedFilt7 in medutils.
@@ -429,7 +429,7 @@ def sepmedfilt9(np.ndarray[np.float32_t, ndim=2, mode='c', cast=True] dsep9):
     -----
     The separable median medians the rows followed by the columns instead of
     using a square window. Therefore it is not identical to the full median
-    filter but it is approximatly the same, but it is signifcantly faster.
+    filter but it is approximately the same, but it is significantly faster.
     The median filter is not calculated for a 4 pixel border around the image.
     These pixel values are copied from the input data. The array needs to be
     C-contiguous order. Wrapper for PySepMedFilt9 in medutils.


### PR DESCRIPTION
Fix mistakes: Guassian, approximatly and signifcantly.