### PR TITLE
Update astropy-helpers to v2.0.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -79,8 +79,6 @@ matrix:
           env: SETUP_CMD='build_sphinx -w'
 
         # Try Astropy development version
-        - python: 2.7
-          env: ASTROPY_VERSION=development
         - python: 3.5
           env: ASTROPY_VERSION=development
         - python: 2.7


### PR DESCRIPTION
This is an automated update of the astropy-helpers submodule to v2.0.2. This includes both the update of the astropy-helpers sub-module, and the ``ah_bootstrap.py`` file, if needed.

*This is intended to be helpful, but if you would prefer to manage these updates yourself, or if you notice any issues with this automated update, please let @bsipocz or @astrofrog know!*