### PR TITLE
Default to CFLAGS environment variable for setup if it exists.

### DIFF
--- a/astroscrappy/utils/setup_package.py
+++ b/astroscrappy/utils/setup_package.py
@@ -68,21 +68,22 @@ def get_extensions():
     include_dirs = ['numpy', UTIL_DIR]
 
     libraries = []
-
+    if 'CFLAGS' in os.environ:
+        extra_compile_args = os.environ['CFLAGS'].split()
+    else:
+        extra_compile_args = ['-g', '-O3', '-funroll-loops','-ffast-math']
     ext_med = Extension(name=str('astroscrappy.utils.median_utils'),
                     sources=med_sources,
                     include_dirs=include_dirs,
                     libraries=libraries,
                     language="c",
-                    extra_compile_args=['-g', '-O3', '-funroll-loops',
-                                        '-ffast-math'])
+                    extra_compile_args=extra_compile_args)
     ext_im = Extension(name=str("astroscrappy.utils.image_utils"),
                     sources=im_sources,
                     include_dirs=include_dirs,
                     libraries=libraries,
                     language="c",
-                    extra_compile_args=['-g', '-O3', '-funroll-loops',
-                                        '-ffast-math'])
+                    extra_compile_args=extra_compile_args)
 
     has_openmp, outputs = check_openmp()
     if has_openmp:


### PR DESCRIPTION
This allows users to override the c compiler flags that were hard coded in the setup_package.py for the Cython files.
Fixes issue raised in PR #22. 