### PR TITLE
Cython coverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,6 +40,9 @@ env:
         # overridden underneath. They are defined here in order to save having
         # to repeat them for all configurations.
 
+        # By default, we run our jobs with tox.
+        - SETUP_METHOD='tox'
+
         # The following three variables are for tox. TOXENV is a standard
         # variable that tox uses to determine the environment to run,
         # TOXARGS are arguments passed to tox, and TOXPOSARGS are arguments
@@ -77,8 +80,7 @@ matrix:
           name: Python 3.8 with required dependencies and measure coverage
           stage: Initial tests
           # CFLAGS='--coverage'
-          env: TOXENV=py38-test-cov
-               COVERAGE=1
+          env: SETUP_METHOD='pip'
 
         # Check for sphinx doc build warnings
         - os: linux
@@ -167,8 +169,14 @@ install:
       fi
 
 script:
-    - pip install tox
-    - tox $TOXARGS -- $TOXPOSARGS
+    - if [ $SETUP_METHOD == 'tox' ]; then
+        pip install tox;
+        tox $TOXARGS -- $TOXPOSARGS;
+      else
+        pip install Cython extension-helpers numpy;
+        COVERAGE=1 pip install -e .[test];
+        pytest --pyargs astroscrappy docs --cov astroscrappy;
+      fi
 
 after_success:
     - if [[ $TOXENV == *-cov ]]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -80,7 +80,7 @@ matrix:
           name: Python 3.8 with required dependencies and measure coverage
           stage: Initial tests
           # CFLAGS='--coverage'
-          env: SETUP_METHOD='pip'
+          env: SETUP_METHOD='cov'
 
         # Check for sphinx doc build warnings
         - os: linux
@@ -179,7 +179,7 @@ script:
       fi
 
 after_success:
-    - if [[ $TOXENV == *-cov ]]; then
+    - if [ $SETUP_METHOD == 'cov' ]; then
         pip install codecov;
         codecov;
       fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -76,8 +76,8 @@ matrix:
           python: 3.8
           name: Python 3.8 with required dependencies and measure coverage
           stage: Initial tests
+          # CFLAGS='--coverage'
           env: TOXENV=py38-test-cov
-               CFLAGS='--coverage'
                COVERAGE=1
 
         # Check for sphinx doc build warnings

--- a/.travis.yml
+++ b/.travis.yml
@@ -77,7 +77,8 @@ matrix:
           name: Python 3.8 with required dependencies and measure coverage
           stage: Initial tests
           env: TOXENV=py38-test-cov
-               CFLAGS='-ftest-coverage'
+               CFLAGS='--coverage'
+               COVERAGE=1
 
         # Check for sphinx doc build warnings
         - os: linux

--- a/astroscrappy/astroscrappy.pyx
+++ b/astroscrappy/astroscrappy.pyx
@@ -1,7 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-# cython: profile=True, boundscheck=False, nonecheck=False, wraparound=False
-# cython: language_level=3, cdivision=True, linetrace=True
-# distutils: define_macros=CYTHON_TRACE=1
+# cython: boundscheck=False, nonecheck=False, wraparound=False
+# cython: language_level=3, cdivision=True
 """
 Name : astroscrappy: The Speedy Cosmic Ray Annihilation Package in Python
 Author : Curtis McCully

--- a/astroscrappy/utils/image_utils.pyx
+++ b/astroscrappy/utils/image_utils.pyx
@@ -1,7 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-# cython: profile=True, boundscheck=False, nonecheck=False, wraparound=False
-# cython: language_level=3, cdivision=True, linetrace=True
-# distutils: define_macros=CYTHON_TRACE=1
+# cython: boundscheck=False, nonecheck=False, wraparound=False
+# cython: language_level=3, cdivision=True
 """
 Name : image_utils
 Author : Curtis McCully

--- a/astroscrappy/utils/median_utils.pyx
+++ b/astroscrappy/utils/median_utils.pyx
@@ -1,7 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-# cython: profile=True, boundscheck=False, nonecheck=False, wraparound=False
-# cython: language_level=3, cdivision=True, linetrace=True
-# distutils: define_macros=CYTHON_TRACE=1
+# cython: boundscheck=False, nonecheck=False, wraparound=False
+# cython: language_level=3, cdivision=True
 """
 Name : median_utils
 Author : Curtis McCully

--- a/setup.py
+++ b/setup.py
@@ -84,7 +84,7 @@ if os.getenv('COVERAGE'):
     print('Adding linetrace directive')
     compiler_directives['profile'] = True
     compiler_directives['linetrace'] = True
-    os.environ['CFLAGS'] = '-DCYTHON_TRACE=1 --coverage -fno-inline-functions -O0'
+    os.environ['CFLAGS'] = '-DCYTHON_TRACE_NOGIL=1 --coverage -fno-inline-functions -O0'
 
 ext_modules = cythonize(ext_modules, compiler_directives=compiler_directives)
 

--- a/setup.py
+++ b/setup.py
@@ -75,7 +75,19 @@ except Exception:
 
 # Import this later to allow checking deprecated options before
 from extension_helpers import get_extensions  # noqa
+from Cython.Build import cythonize  # noqa
+
+ext_modules = get_extensions()
+compiler_directives = {}
+
+if os.getenv('COVERAGE'):
+    print('Adding linetrace directive')
+    compiler_directives['profile'] = True
+    compiler_directives['linetrace'] = True
+    os.environ['CFLAGS'] = '-DCYTHON_TRACE=1'
+
+ext_modules = cythonize(ext_modules, compiler_directives=compiler_directives)
 
 setup(use_scm_version={'write_to': os.path.join('astroscrappy', 'version.py'),
                        'write_to_template': VERSION_TEMPLATE},
-      ext_modules=get_extensions())
+      ext_modules=ext_modules)

--- a/setup.py
+++ b/setup.py
@@ -84,7 +84,7 @@ if os.getenv('COVERAGE'):
     print('Adding linetrace directive')
     compiler_directives['profile'] = True
     compiler_directives['linetrace'] = True
-    os.environ['CFLAGS'] = '-DCYTHON_TRACE=1'
+    os.environ['CFLAGS'] = '-DCYTHON_TRACE=1 --coverage -fno-inline-functions -O0'
 
 ext_modules = cythonize(ext_modules, compiler_directives=compiler_directives)
 

--- a/tox.ini
+++ b/tox.ini
@@ -17,10 +17,6 @@ isolated_build = true
 # Pass through the following environment variables which may be needed for the CI
 passenv = HOME WINDIR LC_ALL LC_CTYPE CC CI TRAVIS TRAVIS_* COVERAGE
 
-# For coverage, we need to pass extra options to the C compiler
-# setenv =
-#     cov: CFLAGS = --coverage -fno-inline-functions -O0
-
 # Run the tests in a temporary directory to make sure that we don't import
 # this package from the source tree
 changedir = .tmp/{envname}

--- a/tox.ini
+++ b/tox.ini
@@ -10,8 +10,7 @@ requires =
     setuptools >= 30.3.0
     pip >= 19.3.1
 
-# Cannot use isolated build with the develop mode, and factors don't work here.
-# isolated_build = true
+isolated_build = true
 
 [testenv]
 
@@ -22,14 +21,9 @@ passenv = HOME WINDIR LC_ALL LC_CTYPE CC CI TRAVIS TRAVIS_* COVERAGE
 # setenv =
 #     cov: CFLAGS = --coverage -fno-inline-functions -O0
 
-usedevelop =
-    cov: true
-    !cov: false
-
 # Run the tests in a temporary directory to make sure that we don't import
 # this package from the source tree
-changedir =
-    !cov: .tmp/{envname}
+changedir = .tmp/{envname}
 
 # tox environments are constructed with so-called 'factors' (or terms)
 # separated by hyphens, e.g. test-devdeps-cov. Lines below starting with factor:
@@ -54,9 +48,6 @@ description =
 
 # The following provides some specific pinnings for key packages
 deps =
-    Cython
-    extension-helpers
-
     numpy116: numpy==1.16.*
     numpy117: numpy==1.17.*
     numpy118: numpy==1.18.*

--- a/tox.ini
+++ b/tox.ini
@@ -9,16 +9,26 @@ envlist =
 requires =
     setuptools >= 30.3.0
     pip >= 19.3.1
-isolated_build = true
+
+# Cannot use isolated build with the develop mode.
+# isolated_build = true
 
 [testenv]
 
 # Pass through the following environment variables which may be needed for the CI
-passenv = HOME WINDIR LC_ALL LC_CTYPE CC CI TRAVIS TRAVIS_*
+passenv = HOME WINDIR LC_ALL LC_CTYPE CC CI TRAVIS TRAVIS_* COVERAGE
+
+# For coverage, we need to pass extra options to the C compiler
+# setenv =
+#     cov: CFLAGS = --coverage -fno-inline-functions -O0
+
+usedevelop =
+    cov: true
+    !cov: false
 
 # Run the tests in a temporary directory to make sure that we don't import
 # this package from the source tree
-changedir = .tmp/{envname}
+# changedir = .tmp/{envname}
 
 # tox environments are constructed with so-called 'factors' (or terms)
 # separated by hyphens, e.g. test-devdeps-cov. Lines below starting with factor:
@@ -43,6 +53,7 @@ description =
 
 # The following provides some specific pinnings for key packages
 deps =
+    Cython
 
     numpy116: numpy==1.16.*
     numpy117: numpy==1.17.*

--- a/tox.ini
+++ b/tox.ini
@@ -54,8 +54,8 @@ description =
 
 # The following provides some specific pinnings for key packages
 deps =
-    cov: Cython
-    cov: extension-helpers
+    Cython
+    extension-helpers
 
     numpy116: numpy==1.16.*
     numpy117: numpy==1.17.*

--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,7 @@ requires =
     setuptools >= 30.3.0
     pip >= 19.3.1
 
-# Cannot use isolated build with the develop mode.
+# Cannot use isolated build with the develop mode, and factors don't work here.
 # isolated_build = true
 
 [testenv]
@@ -28,7 +28,8 @@ usedevelop =
 
 # Run the tests in a temporary directory to make sure that we don't import
 # this package from the source tree
-# changedir = .tmp/{envname}
+changedir =
+    !cov: .tmp/{envname}
 
 # tox environments are constructed with so-called 'factors' (or terms)
 # separated by hyphens, e.g. test-devdeps-cov. Lines below starting with factor:
@@ -53,7 +54,8 @@ description =
 
 # The following provides some specific pinnings for key packages
 deps =
-    Cython
+    cov: Cython
+    cov: extension-helpers
 
     numpy116: numpy==1.16.*
     numpy117: numpy==1.17.*


### PR DESCRIPTION
Fix #30. 

To get the Cython coverage, we need a "develop" build.
Also I moved the `linetrace` and `profile` directives, as well as definition of `CYTHON_TRACE=1`, to be optional since it can have a performance impact for normal builds. So this is activated in the `setup.py` by setting the `COVERAGE` env var.

Refs:
https://medium.com/@dfdeshom/better-test-coverage-workflow-for-cython-modules-631615eb197a
http://blog.behnel.de/posts/coverage-analysis-for-cython-modules.html