### PR TITLE
Fix deprecated numpy

### DIFF
--- a/astroscrappy/astroscrappy.pyx
+++ b/astroscrappy/astroscrappy.pyx
@@ -417,7 +417,7 @@ def detect_cosmics(indat, inmask=None, inbkg=None, invar=None, float sigclip=4.5
 
     cleanarr /= gain
 
-    return crmask.astype(np.bool), cleanarr
+    return crmask.astype(bool), cleanarr
 
 
 def update_mask(np.ndarray[np.float32_t, ndim=2, mode='c', cast=True] data,

--- a/astroscrappy/tests/fake_data.py
+++ b/astroscrappy/tests/fake_data.py
@@ -60,6 +60,6 @@ def make_fake_data():
     imdata = imdata.astype('f4')
 
     # Make a mask where the detected cosmic rays should be
-    crmask = np.zeros((1001, 1001), dtype=np.bool)
+    crmask = np.zeros((1001, 1001), dtype=bool)
     crmask[cr_y, cr_x] = True
     return imdata, crmask

--- a/astroscrappy/tests/test_utils.py
+++ b/astroscrappy/tests/test_utils.py
@@ -139,7 +139,7 @@ def test_sepmedfilt9():
 
 def test_dilate5():
     # Put 5% of the pixels into a mask
-    a = np.zeros((1001, 1001), dtype=np.bool)
+    a = np.zeros((1001, 1001), dtype=bool)
     a[np.random.random((1001, 1001)) < 0.05] = True
     kernel = np.ones((5, 5))
     kernel[0, 0] = 0
@@ -147,7 +147,7 @@ def test_dilate5():
     kernel[4, 0] = 0
     kernel[4, 4] = 0
     # Make a zero padded array for the numpy version to operate
-    paddeda = np.zeros((1005, 1005), dtype=np.bool)
+    paddeda = np.zeros((1005, 1005), dtype=bool)
     paddeda[2:-2, 2:-2] = a[:, :]
     npdilate = binary_dilation(np.ascontiguousarray(paddeda),
                                structure=kernel, iterations=2)
@@ -158,7 +158,7 @@ def test_dilate5():
 
 def test_dilate3():
     # Put 5% of the pixels into a mask
-    a = np.zeros((1001, 1001), dtype=np.bool)
+    a = np.zeros((1001, 1001), dtype=bool)
     a[np.random.random((1001, 1001)) < 0.05] = True
     kernel = np.ones((3, 3))
     npgrow = binary_dilation(np.ascontiguousarray(a),

--- a/astroscrappy/utils/image_utils.pyx
+++ b/astroscrappy/utils/image_utils.pyx
@@ -210,7 +210,7 @@ def dilate3(np.ndarray[np.uint8_t, ndim=2, mode='c', cast=True] dgrow):
 
     # Allocate the output array here so that Python tracks the memory and will
     # free the memory when we are finished with the output array.
-    output = np.zeros((ny, nx), dtype=np.bool)
+    output = np.zeros((ny, nx), dtype=bool)
 
     cdef uint8_t * dgrowptr = < uint8_t * > np.PyArray_DATA(dgrow)
     cdef uint8_t * outdgrowptr = < uint8_t * > np.PyArray_DATA(output)
@@ -256,7 +256,7 @@ def dilate5(np.ndarray[np.uint8_t, ndim=2, mode='c', cast=True] ddilate,
 
     # Allocate the output array here so that Python tracks the memory and will
     # free the memory when we are finished with the output array.
-    output = np.zeros((ny, nx), dtype=np.bool)
+    output = np.zeros((ny, nx), dtype=bool)
 
     cdef uint8_t * ddilateptr = < uint8_t * > np.PyArray_DATA(ddilate)
     cdef uint8_t * outddilateptr = < uint8_t * > np.PyArray_DATA(output)


### PR DESCRIPTION
Hello,

A small effort to replace some instances of deprecated `np.bool` with `bool` while working on astropy/ccdproc#759. This can remove such warnings in projects where astroscrappy is used.

Thanks!!