### PR TITLE
MNT: Replace master with main

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -3,7 +3,7 @@ name: Run unit tests
 on:
   pull_request:
   push:
-    branches: [ master ]
+    branches: [ main ]
     tags:
   workflow_dispatch:
   schedule:

--- a/README.rst
+++ b/README.rst
@@ -8,7 +8,7 @@ Astro-SCRAPPY: The Speedy Cosmic Ray Annihilation Package in Python
 .. image:: https://github.com/astropy/astroscrappy/workflows/Run%20unit%20tests/badge.svg
     :target: https://github.com/astropy/astroscrappy/actions
     :alt: CI Status
-.. image:: https://codecov.io/gh/astropy/astroscrappy/branch/master/graph/badge.svg
+.. image:: https://codecov.io/gh/astropy/astroscrappy/branch/main/graph/badge.svg
     :target: https://codecov.io/gh/astropy/astroscrappy
     :alt: AstroScrappy's Coverage Status
 .. image:: https://zenodo.org/badge/36837126.svg

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -159,7 +159,7 @@ if setup_cfg.get('edit_on_github').lower() == 'true':
     extensions += ['sphinx_astropy.ext.edit_on_github']
 
     edit_on_github_project = setup_cfg['github_project']
-    edit_on_github_branch = "master"
+    edit_on_github_branch = "main"
 
     edit_on_github_source_root = ""
     edit_on_github_doc_root = "docs"


### PR DESCRIPTION
This PR attempts to replace all mention of `master` to `main` in this repository. This should be reviewed and merged right after the maintainer has renamed the default branch.

This is an automated update made by the `batchpr` tool :robot: - feel free to close if it doesn't look good! You can report issues to @pllim.

This is part of #61