### PR TITLE
Update CI jobs, drop Python 3.6

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -34,7 +34,7 @@ jobs:
 
           - name: Python 3.10 with required dependencies
             os: ubuntu-latest
-            python-version: 3.10
+            python-version: "3.10"
             toxenv: py310-test
 
           - name: Documentation build

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -27,30 +27,20 @@ jobs:
             toxenv: py38-test
             coverage: true
 
+          - name: Python 3.9 with required dependencies
+            os: windows-latest
+            python-version: 3.9
+            toxenv: py39-test
+
+          - name: Python 3.10 with required dependencies
+            os: ubuntu-latest
+            python-version: 3.10
+            toxenv: py310-test
+
           - name: Documentation build
             os: ubuntu-latest
             python-version: 3.8
             toxenv: build_docs
-
-          - name: Python 3.8 with developer version of astropy and numpy
-            os: ubuntu-latest
-            python-version: 3.8
-            toxenv: py38-test-devdeps
-
-          - name: Python 3.6 astropy LTS and Numpy 1.16
-            os: ubuntu-latest
-            python-version: 3.6
-            toxenv: py36-test-astropylts-numpy116
-
-          - name: Python 3.8 with required dependencies
-            os: windows-latest
-            python-version: 3.8
-            toxenv: py38-test
-
-          - name: Python 3.7 with older dependencies, astropy 3.0 and Numpy 1.17
-            os: ubuntu-latest
-            python-version: 3.7
-            toxenv: py37-test-astropy30-numpy117
 
           - name: Code style checks
             os: ubuntu-latest

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,10 +1,17 @@
-1.1.0 (2020-11-01)
+1.2.0.dev (unreleased)
+----------------------
+
+- Drop support for Python 3.6.
+
+1.1.0 (2021-11-19)
 ------------------
+
 - Added the option to add a variance array
 - Added the ability to subtract a background array rather than a single value.
 
 1.0.5 (2016-08-16)
 ------------------
+
 - Updated to newest version of astropy package template.
 
 - Fixed median cleaning. There was a subtle bug that the crmask was defined as a unit8

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,7 +14,7 @@ github_project = astropy/astroscrappy
 [options]
 zip_safe = False
 packages = find:
-python_requires = >=3.6
+python_requires = >=3.7
 setup_requires = setuptools_scm
 install_requires =
     astropy

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 envlist =
-    py{36,37,38,39}-test{,-alldeps,-devdeps}{,-cov}
-    py{36,37,38,39}-test-numpy{116,117,118,119}
-    py{36,37,38,39}-test-astropy{30,40,41,lts}
+    py{37,38,39,310}-test{,-alldeps,-devdeps}{,-cov}
+    py{37,38,39,310}-test-numpy{117,118,119,120}
+    py{37,38,39,310}-test-astropy{30,40,41,lts}
     build_docs
     linkcheck
     codestyle
@@ -51,6 +51,7 @@ deps =
     numpy117: numpy==1.17.*
     numpy118: numpy==1.18.*
     numpy119: numpy==1.19.*
+    numpy120: numpy==1.20.*
 
     astropy30: astropy==3.0.*
     astropy40: astropy==4.0.*


### PR DESCRIPTION
Python 3.6 is no more supported (Astropy 5.0 even dropped support for 3.7!) and there were no build for 3.10.
Also I don't think we need to test astropydev and numpydev. Astropy is used only for the test runner and some test config (astroscrappy could even not depend on it), and the usage of Numpy is rather basic (mostly array creation and logical operations). So I think we can simplify the test matrix, and I could do the same for tox if you agree.