### PR TITLE
Update CI and requirements

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -16,15 +16,10 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - name: Python 3.7 with required dependencies
-            os: macos-latest
-            python-version: 3.7
-            toxenv: py37-test
-
           - name: Python 3.8 with required dependencies and measure coverage
             os: ubuntu-latest
             python-version: 3.8
-            toxenv: py38-test
+            toxenv: py38-test-numpy122
             coverage: true
 
           - name: Python 3.9 with required dependencies
@@ -35,12 +30,18 @@ jobs:
           - name: Python 3.10 with required dependencies
             os: ubuntu-latest
             python-version: "3.10"
-            toxenv: py310-test
+            toxenv: py310-test-numpy124
 
-          - name: Documentation build
+          - name: Python 3.11 with required dependencies
+            os: macos-latest
+            python-version: "3.11"
+            toxenv: py311-test-astropy53
+
+          - name: Python 3.12 with required dependencies
             os: ubuntu-latest
-            python-version: 3.8
-            toxenv: build_docs
+            python-version: "3.12"
+            toxenv: py312-test
+            coverage: true
 
           - name: Code style checks
             os: ubuntu-latest
@@ -57,9 +58,6 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
       run: python -m pip install tox
-    - name: Install graphviz dependency
-      if: "endsWith(matrix.toxenv, 'build_docs')"
-      run: sudo apt-get -y install graphviz
     - name: Run tests
       if: "! matrix.coverage"
       run: tox -v -e ${{ matrix.toxenv }}

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -16,16 +16,10 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - name: Python 3.8 with required dependencies and measure coverage
-            os: ubuntu-latest
-            python-version: 3.8
-            toxenv: py38-test-numpy122
-            coverage: true
-
           - name: Python 3.9 with required dependencies
             os: windows-latest
             python-version: 3.9
-            toxenv: py39-test
+            toxenv: py39-test-numpy122
 
           - name: Python 3.10 with required dependencies
             os: ubuntu-latest
@@ -45,15 +39,15 @@ jobs:
 
           - name: Code style checks
             os: ubuntu-latest
-            python-version: 3.8
+            python-version: "3.12"
             toxenv: codestyle
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 0
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,20 +10,20 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-20.04, windows-2019, macos-10.15]
+        os: [ubuntu-latest, windows-latest, macos-latest]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
         name: Install Python
         with:
-          python-version: '3.8'
+          python-version: '3.12'
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.2.2
+        uses: pypa/cibuildwheel@v2.16.2
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           path: ./wheelhouse/*.whl
 
@@ -31,19 +31,19 @@ jobs:
     name: Build source distribution
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
         name: Install Python
         with:
-          python-version: '3.8'
+          python-version: '3.12'
 
       - name: Build sdist
         run:  |
           python -m pip install build
           python -m build --sdist
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           path: dist/*.tar.gz
 
@@ -53,12 +53,12 @@ jobs:
     # upload to PyPI on every tag
     if: startsWith(github.ref, 'refs/tags')
     steps:
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: artifact
           path: dist
 
-      - uses: pypa/gh-action-pypi-publish@v1.4.2
+      - uses: pypa/gh-action-pypi-publish@v1
         with:
           user: __token__
           password: ${{ secrets.pypi_token }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - uses: actions/setup-python@v4
         name: Install Python
@@ -32,6 +34,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - uses: actions/setup-python@v4
         name: Install Python

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,8 +10,13 @@ build-backend = 'setuptools.build_meta'
 
 [tool.cibuildwheel]
 # Skip pypy on mac due to numpy/accelerate issues
-skip = "pp* cp*-manylinux_i686 *musllinux*"
-test-skip = "cp9-win* cp10-win*"
+skip = ["pp*", "*musllinux*"]
 environment = { PIP_PREFER_BINARY=1 }
 test-requires = "pytest scipy"
 test-command = "pytest --pyargs astroscrappy"
+
+[tool.cibuildwheel.linux]
+archs = ["x86_64"]
+
+[tool.cibuildwheel.windows]
+archs = ["AMD64"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,10 +2,9 @@
 
 requires = ["setuptools",
             "setuptools_scm",
-            "wheel",
             "extension-helpers==1.*",
-            "oldest-supported-numpy",
-            "Cython>=0.29.21,<3.0"]
+            "numpy>=1.25,<2",
+            "Cython>=3.0,<3.1"]
 
 build-backend = 'setuptools.build_meta'
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,8 @@ build-backend = 'setuptools.build_meta'
 
 [tool.cibuildwheel]
 # Skip pypy on mac due to numpy/accelerate issues
-skip = "pp37* cp36* cp310-win* cp*-manylinux_i686 *musllinux*"
+skip = "pp* cp*-manylinux_i686 *musllinux*"
+test-skip = "cp9-win*"
+environment = { PIP_PREFER_BINARY=1 }
 test-requires = "pytest scipy"
 test-command = "pytest --pyargs astroscrappy"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,6 @@ build-backend = 'setuptools.build_meta'
 
 [tool.cibuildwheel]
 # Skip pypy on mac due to numpy/accelerate issues
-skip = "pp37* cp36* cp310-win* cp310-manylinux_x86_64 cp*-manylinux_i686 *musllinux*"
+skip = "pp37* cp36* cp310-win* cp*-manylinux_i686 *musllinux*"
 test-requires = "pytest scipy"
 test-command = "pytest --pyargs astroscrappy"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ build-backend = 'setuptools.build_meta'
 [tool.cibuildwheel]
 # Skip pypy on mac due to numpy/accelerate issues
 skip = "pp* cp*-manylinux_i686 *musllinux*"
-test-skip = "cp9-win*"
+test-skip = "cp9-win* cp10-win*"
 environment = { PIP_PREFER_BINARY=1 }
 test-requires = "pytest scipy"
 test-command = "pytest --pyargs astroscrappy"

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,7 +14,7 @@ github_project = astropy/astroscrappy
 [options]
 zip_safe = False
 packages = find:
-python_requires = >=3.7
+python_requires = >=3.8
 setup_requires = setuptools_scm
 install_requires =
     astropy

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,7 +14,7 @@ github_project = astropy/astroscrappy
 [options]
 zip_safe = False
 packages = find:
-python_requires = >=3.8
+python_requires = >=3.9
 setup_requires = setuptools_scm
 install_requires =
     astropy

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 envlist =
-    py{37,38,39,310}-test{,-alldeps,-devdeps}{,-cov}
-    py{37,38,39,310}-test-numpy{117,118,119,120}
-    py{37,38,39,310}-test-astropy{30,40,41,lts}
+    py{38,39,310,311,312}-test{,-alldeps,-devdeps}{,-cov}
+    py{38,39,310,311,312}-test-numpy{122,124,126}
+    py{38,39,310,311,312}-test-astropy{53,60}
     build_docs
     linkcheck
     codestyle
@@ -36,27 +36,15 @@ description =
     devdeps: with the latest developer version of key dependencies
     oldestdeps: with the oldest supported version of key dependencies
     cov: and test coverage
-    numpy116: with numpy 1.16.*
-    numpy117: with numpy 1.17.*
-    numpy118: with numpy 1.18.*
-    numpy119: with numpy 1.19.*
-    astropy30: with astropy 3.0.*
-    astropy40: with astropy 4.0.*
-    astropy41: with astropy 4.1.*
-    astropylts: with the latest astropy LTS
 
 # The following provides some specific pinnings for key packages
 deps =
-    numpy116: numpy==1.16.*
-    numpy117: numpy==1.17.*
-    numpy118: numpy==1.18.*
-    numpy119: numpy==1.19.*
-    numpy120: numpy==1.20.*
+    numpy122: numpy==1.22.*
+    numpy124: numpy==1.24.*
+    numpy126: numpy==1.26.*
 
-    astropy30: astropy==3.0.*
-    astropy40: astropy==4.0.*
-    astropy41: astropy==4.1.*
-    astropylts: astropy==4.0.*
+    astropy53: astropy==5.3.*
+    astropy60: astropy==6.0.*
 
     devdeps: :NIGHTLY:numpy
     devdeps: git+https://github.com/astropy/astropy.git#egg=astropy

--- a/tox.ini
+++ b/tox.ini
@@ -1,21 +1,20 @@
 [tox]
 envlist =
-    py{38,39,310,311,312}-test{,-alldeps,-devdeps}{,-cov}
-    py{38,39,310,311,312}-test-numpy{122,124,126}
-    py{38,39,310,311,312}-test-astropy{53,60}
+    py{39,310,311,312}-test{,-alldeps,-devdeps}{,-cov}
+    py{39,310,311,312}-test-numpy{122,124,126}
+    py{39,310,311,312}-test-astropy{53,60}
     build_docs
     linkcheck
     codestyle
-requires =
-    setuptools >= 30.3.0
-    pip >= 19.3.1
-indexserver =
-    NIGHTLY = https://pypi.anaconda.org/scientific-python-nightly-wheels/simple
 
 [testenv]
 
 # Pass through the following environment variables which may be needed for the CI
 passenv = HOME,WINDIR,LC_ALL,LC_CTYPE,CC,CI,COVERAGE
+
+setenv =
+    MPLBACKEND=agg
+    devdeps: PIP_EXTRA_INDEX_URL = https://pypi.anaconda.org/scientific-python-nightly-wheels/simple https://pypi.anaconda.org/astropy/simple
 
 # Run the tests in a temporary directory to make sure that we don't import
 # this package from the source tree
@@ -45,8 +44,8 @@ deps =
     astropy53: astropy==5.3.*
     astropy60: astropy==6.0.*
 
-    devdeps: :NIGHTLY:numpy
-    devdeps: git+https://github.com/astropy/astropy.git#egg=astropy
+    devdeps: numpy>=0.0.dev0
+    devdeps: astropy>=0.0.dev0
 
 # The following indicates which extras_require from setup.cfg will be installed
 extras =

--- a/tox.ini
+++ b/tox.ini
@@ -9,14 +9,13 @@ envlist =
 requires =
     setuptools >= 30.3.0
     pip >= 19.3.1
-isolated_build = true
 indexserver =
     NIGHTLY = https://pypi.anaconda.org/scientific-python-nightly-wheels/simple
 
 [testenv]
 
 # Pass through the following environment variables which may be needed for the CI
-passenv = HOME,WINDIR,LC_ALL,LC_CTYPE,CC,CI,TRAVIS,TRAVIS_*,COVERAGE
+passenv = HOME,WINDIR,LC_ALL,LC_CTYPE,CC,CI,COVERAGE
 
 # Run the tests in a temporary directory to make sure that we don't import
 # this package from the source tree


### PR DESCRIPTION
Require Python 3.9+, add CI job for Python 3.11 and 3.12