### PR TITLE
BLD: build against numpy 2.0.0rc1 (or newer)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@
 requires = ["setuptools",
             "setuptools_scm",
             "extension-helpers==1.*",
-            "numpy>=1.25,<2",
+            "numpy>=2.0.0rc1",
             "Cython>=3.0,<3.1"]
 
 build-backend = 'setuptools.build_meta'


### PR DESCRIPTION
A new release with wheels built against NumPy 2.0.0rc1 is necessary for runtime compatibility with NumPy 2 (while retaining compat with NumPy 1.x).
This is needed to test downstream projects (for instance ccdproc) against NumPy 2.0 + astropy 6.1
I have tested locally that tests pass against NumPy 2