### PR TITLE
Rename bool, true and false to avoid conflicts

### DIFF
--- a/astroscrappy/utils/imutils.c
+++ b/astroscrappy/utils/imutils.c
@@ -334,7 +334,7 @@ PyLaplaceConvolve(float* data, float* output, int nx, int ny)
  * data[i + nx * j].
  */
 void
-PyDilate3(bool* data, bool* output, int nx, int ny)
+PyDilate3(bool_t* data, bool_t* output, int nx, int ny)
 {
     PyDoc_STRVAR(PyDilate3__doc__,
         "PyDilate3(data, output, nx, ny) -> void\n\n"
@@ -355,7 +355,7 @@ PyDilate3(bool* data, bool* output, int nx, int ny)
 
     /* Pixel value p. Each thread needs its own unique copy of this so we don't
      initialize this until the pragma below. */
-    bool p;
+    bool_t p;
 
 #pragma omp parallel for firstprivate(output, data, nxny, nx, ny) \
     private(i, j, nxj, p)
@@ -419,7 +419,7 @@ PyDilate3(bool* data, bool* output, int nx, int ny)
  * memory location of pixel i,j is data[i + nx * j].
  */
 void
-PyDilate5(bool* data, bool* output, int niter, int nx, int ny)
+PyDilate5(bool_t* data, bool_t* output, int niter, int nx, int ny)
 {
     PyDoc_STRVAR(PyDilate5__doc__,
         "PyDilate5(data, output, nx, ny) -> void\n\n"
@@ -445,7 +445,7 @@ PyDilate5(bool* data, bool* output, int niter, int nx, int ny)
     int nxny = nx * ny;
 
     /* The padded array to work on */
-    bool* padarr = (bool *) malloc(padnxny * sizeof(bool));
+    bool_t* padarr = (bool_t *) malloc(padnxny * sizeof(bool_t));
 
     /*Loop indices */
     int i, j, nxj, padnxj;
@@ -453,24 +453,24 @@ PyDilate5(bool* data, bool* output, int niter, int nx, int ny)
 
     /* Pixel value p. This needs to be unique for each thread so we initialize
      * it below inside the pragma. */
-    bool p;
+    bool_t p;
 
 #pragma omp parallel firstprivate(padarr, padnx, padnxny) private(i)
     /* Initialize the borders of the padded array to zero */
     for (i = 0; i < padnx; i++) {
-        padarr[i] = false;
-        padarr[i + padnx] = false;
-        padarr[padnxny - padnx + i] = false;
-        padarr[padnxny - padnx - padnx + i] = false;
+        padarr[i] = false_v;
+        padarr[i + padnx] = false_v;
+        padarr[padnxny - padnx + i] = false_v;
+        padarr[padnxny - padnx - padnx + i] = false_v;
     }
 
 #pragma omp parallel firstprivate(padarr, padnx, padny) private(j, padnxj)
     for (j = 0; j < padny; j++) {
         padnxj = padnx * j;
-        padarr[padnxj] = false;
-        padarr[padnxj + 1] = false;
-        padarr[padnxj + padnx - 1] = false;
-        padarr[padnxj + padnx - 2] = false;
+        padarr[padnxj] = false_v;
+        padarr[padnxj + 1] = false_v;
+        padarr[padnxj + padnx - 1] = false_v;
+        padarr[padnxj + padnx - 2] = false_v;
     }
 
 #pragma omp parallel firstprivate(output, data, nxny) private(i)

--- a/astroscrappy/utils/imutils.h
+++ b/astroscrappy/utils/imutils.h
@@ -16,9 +16,9 @@
 #include <stdint.h> 
 
 /* Define a bool type because there isn't one built in ANSI C */
-typedef uint8_t bool;
-#define true 1
-#define false 0
+typedef uint8_t bool_t;
+#define true_v 1
+#define false_v 0
 
 /* Subsample an array 2x2 given an input array data with size nx x ny. Each
  * pixel is replicated into 4 pixels; no averaging is performed. The results
@@ -77,7 +77,7 @@ PyLaplaceConvolve(float* data, float* output, int nx, int ny);
  * data[i + nx * j].
  */
 void
-PyDilate3(bool* data, bool* output, int nx, int ny);
+PyDilate3(bool_t* data, bool_t* output, int nx, int ny);
 
 /* Do niter iterations of boolean dilation on an array of size nx x ny. The
  * results are saved in the output array. The output array should already be
@@ -95,6 +95,6 @@ PyDilate3(bool* data, bool* output, int nx, int ny);
  * memory location of pixel i,j is data[i + nx * j].
  */
 void
-PyDilate5(bool* data, bool* output, int iter, int nx, int ny);
+PyDilate5(bool_t* data, bool_t* output, int iter, int nx, int ny);
 
 #endif /* IMUTILS_H_ */

--- a/astroscrappy/utils/medutils.c
+++ b/astroscrappy/utils/medutils.c
@@ -63,7 +63,7 @@ PyMedian(float* a, int n)
     }
 
     /* Start an infinite loop */
-    while (true) {
+    while (true_v) {
 
         /* Only One or two elements left */
         if (high <= low + 1) {
@@ -92,7 +92,7 @@ PyMedian(float* a, int n)
          * swap items when stuck */
         ll = low + 1;
         hh = high;
-        while (true) {
+        while (true_v) {
             do
                 ll++;
             while (arr[low] > arr[ll]);

--- a/astroscrappy/utils/medutils.h
+++ b/astroscrappy/utils/medutils.h
@@ -16,9 +16,9 @@
 #include <stdint.h> 
 
 /* Define a bool type because there isn't one built in ANSI C */
-typedef uint8_t bool;
-#define true 1
-#define false 0
+typedef uint8_t bool_t;
+#define true_v 1
+#define false_v 0
 
 /*Find the median value of an array "a" of length n. */
 float


### PR DESCRIPTION
The C23 standard makes bool, true and false reserved words. This PR renames `bool` as `boolt_t` and `true` and `false` as `true_v` and `false_v`. 